### PR TITLE
feat: add @RateLimited annotation for rate limiting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Bucket4j -->
+		<dependency>
+			<groupId>com.github.vladimir-bukhtoyarov</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>7.6.0</version>
+		</dependency>
+
     </dependencies>
 
 	<build>

--- a/src/main/java/org/mryrt/file_service/Auth/Controller/UserController.java
+++ b/src/main/java/org/mryrt/file_service/Auth/Controller/UserController.java
@@ -5,6 +5,7 @@ import org.mryrt.file_service.Auth.Model.LogInRequest;
 import org.mryrt.file_service.Auth.Model.SignUpRequest;
 import org.mryrt.file_service.Auth.Model.UserDTO;
 import org.mryrt.file_service.Auth.Service.UserService;
+import org.mryrt.file_service.Utility.Annotation.RateLimited;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,12 +18,14 @@ public class UserController {
     @Autowired
     private UserService userService;
 
+    @RateLimited
     @PostMapping("/sign-up")
     public ResponseEntity userSignUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         UserDTO userDTO = userService.userSignUp(signUpRequest);
         return ResponseEntity.ok(userDTO);
     }
 
+    @RateLimited
     @PostMapping("/log-in")
     public ResponseEntity<String> userLogIn(@Valid @RequestBody LogInRequest logInRequest) {
         String userToken  = userService.userLogIn(logInRequest);

--- a/src/main/java/org/mryrt/file_service/Utility/Annotation/RateLimited.java
+++ b/src/main/java/org/mryrt/file_service/Utility/Annotation/RateLimited.java
@@ -1,4 +1,4 @@
-package org.mryrt.file_service.FileService.Annotation;
+package org.mryrt.file_service.Utility.Annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/mryrt/file_service/Utility/Aspect/RateLimitingAspect.java
+++ b/src/main/java/org/mryrt/file_service/Utility/Aspect/RateLimitingAspect.java
@@ -1,0 +1,50 @@
+package org.mryrt.file_service.Utility.Aspect;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.mryrt.file_service.Utility.Annotation.RateLimited;
+import org.mryrt.file_service.Utility.Service.RateLimiterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Aspect
+@Component
+@Slf4j
+public class RateLimitingAspect {
+
+    @Autowired
+    private RateLimiterService rateLimiterService;
+
+    @Around("@annotation(rateLimited)")
+    public Object applyRateLimiting(ProceedingJoinPoint joinPoint, RateLimited rateLimited) throws Throwable {
+        String key = getClientKey();
+        Bucket bucket = rateLimiterService.resolveBucket(
+                key,
+                rateLimited.maxRequests(),
+                rateLimited.timeWindowSeconds()
+        );
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+        if (!probe.isConsumed()) {
+            long waitForRefill = probe.getNanosToWaitForRefill() / 1_000_000_000;
+            throw new ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    "Too many requests. Please try again in " + waitForRefill + " seconds."
+            );
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private String getClientKey() {
+        var requestAttributes = org.springframework.web.context.request.RequestContextHolder.currentRequestAttributes();
+        var request = ((org.springframework.web.context.request.ServletRequestAttributes) requestAttributes).getRequest();
+        return request.getRemoteAddr();
+    }
+
+}

--- a/src/main/java/org/mryrt/file_service/Utility/Service/RateLimiterService.java
+++ b/src/main/java/org/mryrt/file_service/Utility/Service/RateLimiterService.java
@@ -1,0 +1,30 @@
+package org.mryrt.file_service.Utility.Service;
+
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Refill;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RateLimiterService {
+
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public Bucket resolveBucket(String key, int maxRequests, int timeWindowSeconds) {
+        return buckets.computeIfAbsent(key, _ -> createNewBucket(maxRequests, timeWindowSeconds));
+    }
+
+    private Bucket createNewBucket(int maxRequests, int timeWindowSeconds) {
+        Refill refill = Refill.intervally(maxRequests, java.time.Duration.ofSeconds(timeWindowSeconds));
+        Bandwidth limit = Bandwidth.classic(maxRequests, refill);
+        return Bucket4j.builder()
+                .addLimit(limit)
+                .build();
+    }
+
+}


### PR DESCRIPTION
- Add `@RateLimited` annotation to configure request limits.
- Implement `RateLimitingAspect` to handle rate limiting via Bucket4j.
- Apply annotation to controller methods for endpoint protection.